### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         run: npx projen build
       - name: Check for changes
         id: git_diff
-        run: git diff --exit-code || echo "::set-output name=has_changes::true"
+        run: git diff --exit-code || echo "has_changes=true" >> "$GITHUB_OUTPUT"
       - if: steps.git_diff.outputs.has_changes
         name: Commit and push changes (if changed)
         run: 'git add . && git commit -m "chore: self mutation" && git push origin

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,8 +26,8 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "::set-output name=conclusion::success" || echo
-          "::set-output name=conclusion::failure"
+        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
+          "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -26,8 +26,7 @@ jobs:
         run: npx projen upgrade
       - name: Build
         id: build
-        run: npx projen build && echo "conclusion=success" || echo >> "$GITHUB_OUTPUT"
-          "conclusion=failure" >> "$GITHUB_OUTPUT"
+        run: npx projen build && echo "conclusion=success" >> "$GITHUB_OUTPUT" || echo "conclusion=failure" >> "$GITHUB_OUTPUT"
       - name: Create Patch
         run: |-
           git add .
@@ -58,7 +57,8 @@ jobs:
           name: .upgrade.tmp.patch
           path: ${{ runner.temp }}
       - name: Apply patch
-        run: '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
+        run:
+          '[ -s ${{ runner.temp }}/.upgrade.tmp.patch ] && git apply ${{ runner.temp
           }}/.upgrade.tmp.patch || echo "Empty patch. Skipping."'
       - name: Create Pull Request
         id: create-pr
@@ -97,7 +97,8 @@ jobs:
           signoff: true
       - name: Update status check
         if: steps.create-pr.outputs.pull-request-url != ''
-        run: "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
+        run:
+          "curl -i --fail -X POST -H \"Accept: application/vnd.github.v3+json\" -H
           \"Authorization: token ${GITHUB_TOKEN}\"
           https://api.github.com/repos/${{ github.repository }}/check-runs -d
           '{\"name\":\"build\",\"head_sha\":\"github-actions/upgrade\",\"status\


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter